### PR TITLE
test: add UI tests to verify screens do not crash

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -50,7 +50,12 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlin.inject.runtime)
         }
-        commonTest.dependencies { implementation(libs.kotlin.test) }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+        }
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/whatisthedatetoday/ui/openSourceLicenses/OpenSourceLicensesScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/whatisthedatetoday/ui/openSourceLicenses/OpenSourceLicensesScreenTest.kt
@@ -1,0 +1,17 @@
+package dev.yuyuyuyuyu.whatisthedatetoday.ui.openSourceLicenses
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+class OpenSourceLicensesScreenTest {
+
+    @OptIn(ExperimentalTestApi::class, kotlin.js.ExperimentalWasmJsInterop::class)
+    @Test
+    fun doesNotCrashWhenDisplayed() =
+        kotlinx.coroutines.test.runTest {
+            if (dev.yuyuyuyuyu.whatisthedatetoday.getPlatform().name == "Web with Kotlin/JS")
+                return@runTest
+            runComposeUiTest { setContent { OpenSourceLicensesScreen() } }
+        }
+}

--- a/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/whatisthedatetoday/ui/whatIsTheDateToday/WhatIsTheDateTodayScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/whatisthedatetoday/ui/whatIsTheDateToday/WhatIsTheDateTodayScreenTest.kt
@@ -1,0 +1,38 @@
+package dev.yuyuyuyuyu.whatisthedatetoday.ui.whatIsTheDateToday
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class WhatIsTheDateTodayScreenTest {
+
+    @OptIn(ExperimentalTestApi::class, kotlin.js.ExperimentalWasmJsInterop::class)
+    @Test
+    fun doesNotCrashWhenDisplayed() =
+        kotlinx.coroutines.test.runTest {
+            if (dev.yuyuyuyuyu.whatisthedatetoday.getPlatform().name == "Web with Kotlin/JS")
+                return@runTest
+            runComposeUiTest {
+                setContent {
+                    WhatIsTheDateTodayScreen(
+                        viewModel =
+                            object : WhatIsTheDateTodayViewModel {
+                                override val uiState: StateFlow<WhatIsTheDateTodayUiState> =
+                                    MutableStateFlow(
+                                        WhatIsTheDateTodayUiState(
+                                            japaneseEra = "令和",
+                                            year = 2026,
+                                            japaneseYear = 8,
+                                            month = 5,
+                                            day = 5,
+                                            dayOfWeek = "火",
+                                        )
+                                    )
+                            }
+                    )
+                }
+            }
+        }
+}


### PR DESCRIPTION
- Add compose.uiTest and kotlinx-coroutines-test to commonTest dependencies
- Add WhatIsTheDateTodayScreenTest and OpenSourceLicensesScreenTest
- Run runComposeUiTest to ensure both screens render without crashing
- Skip UI test execution on JS target due to Skia initialization limits
