### PR TITLE
Build the production distribution in CI to match deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,29 @@ jobs:
 
       - name: Run Tests
         run: ./gradlew wasmJsTest
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'jetbrains'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # Mirror the deploy build so a broken production build is caught in CI,
+      # before it is merged to main, instead of failing at deploy time.
+      - name: Export Library Definitions
+        run: ./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/
+
+      - name: Build
+        run: ./gradlew :composeApp:wasmJsBrowserDistribution

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   workflow_run:
-    workflows: [ Tests ]
+    workflows: [ CI ]
     types: [ completed ]
     branches: [ main ]
 


### PR DESCRIPTION
## Why

CI only ran formatting (`spotlessCheck`), lint (`detekt`), and tests (`wasmJsTest`). It **never built the production WasmJs distribution**.

As a result, a change that broke the production build could pass every CI check, get merged into `main`, and only fail later at deploy time — exactly the "looked green, but the deploy build was actually broken" situation we want to avoid.

## What

- **Add a `Build` job to CI** that runs the *exact same* steps as the deploy workflow:
  - `:composeApp:exportLibraryDefinitions`
  - `:composeApp:wasmJsBrowserDistribution`

  Now a broken production build is caught on the PR, before it reaches `main`, instead of at deploy time.

- **Fix the deploy trigger.** `deploy.yml` triggers on `workflow_run` of a workflow named `Tests`, but that workflow was renamed to `CI` on 2026-05-30. The stale name silently stopped deploys from firing (last successful deploy: 2026-05-29). This points the trigger at `CI` so deploys run again after CI passes on `main`.

## Verification

Ran the deploy build steps locally on the current `main`; both succeed:

- `./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/` → `BUILD SUCCESSFUL`
- `./gradlew :composeApp:wasmJsBrowserDistribution` → `BUILD SUCCESSFUL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)