### PR TITLE
ci: remove dead merge_group trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  merge_group:
 
 jobs:
   spotless:


### PR DESCRIPTION
Merge queue isn't available on personal-account repositories (confirmed via API: 422 `Invalid rule 'merge_queue'`), so the `merge_group` trigger added in #60 never fires. This removes the dead trigger.

This repo uses the **Dependabot open-PR limit of 1** (no auto-merge) — that's the CI-waste fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)