### PR TITLE
docs: point the CI badge at ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 今日の日付
 
 [![Deploy](https://github.com/yuyuyuyuyu-dev/what-is-the-date-today/actions/workflows/deploy.yml/badge.svg)](https://github.com/yuyuyuyuyu-dev/what-is-the-date-today/actions/workflows/deploy.yml)
-[![Tests](https://github.com/yuyuyuyuyu-dev/what-is-the-date-today/actions/workflows/tests.yml/badge.svg)](https://github.com/yuyuyuyuyu-dev/what-is-the-date-today/actions/workflows/tests.yml)
+[![CI](https://github.com/yuyuyuyuyu-dev/what-is-the-date-today/actions/workflows/ci.yml/badge.svg)](https://github.com/yuyuyuyuyu-dev/what-is-the-date-today/actions/workflows/ci.yml)
 
 現在の日付を表示するだけの Web アプリです<br />
 健康診断の問診票など、その日の日付を西暦・和暦から書くときに便利です


### PR DESCRIPTION
## Summary

The README badge on line 4 pointed at `.github/workflows/tests.yml`, which no longer exists in this repository. GitHub renders a badge for a missing workflow as "no status", so the badge has been dead.

This points it at `.github/workflows/ci.yml` and renames the label from "Tests" to "CI" to match the workflow's `name: CI`.

## Verification

- Confirmed the workflows present are `ci.yml` (name: CI), `deploy.yml` (name: Deploy), and `dependabot.yml` (name: Dependabot) — there is no `tests.yml`.
- Fetched the new badge URL directly; it returns `<title>CI - failing</title>` rather than "no status", confirming the URL resolves to a real workflow. The failing state reflects the current CI result on `main` and is unrelated to this change.
- `npm run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)